### PR TITLE
Fixed timepicker in Firefox workaround

### DIFF
--- a/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
+++ b/Products/zms/plugins/www/bootstrap/plugin/bootstrap.plugin.zmi.js
@@ -1124,10 +1124,17 @@ ZMI.prototype.initInputFields = function(container) {
 				var icon_picker =  eval('icon_' + $(this).prop('class').split(' ').filter(function(v) {return v.endsWith('picker')}));
 				$(this).before('<div class="input-group-prepend"><span class="input-group-text"><i class="'+ icon_picker +'"></i></span></div>');
 				if (is_firefox) {
-					$(this).attr('type','date');
+					if ($(this).attr('type') == 'datetime-local') {
+						$(this).attr('type', 'date');
+					}
 					$(this).attr('value',$(this).attr('value').split('T')[0]);
 					$(this).dblclick(() => {
-						$(this).attr('type','datetime-local');
+						if ($(this).attr('type') == 'datetime-local') {
+							$(this).attr('type', 'date');
+						}
+						else if ($(this).attr('type') == 'date') {
+							$(this).attr('type', 'datetime-local');
+						}
 						$(this).attr('value',$(this).attr('data-initial-value'));
 					});
 				}


### PR DESCRIPTION
With the Firefox browser `type=date` is set in any case. So instead of a timepicker a datepicker is shown with `type=time`.

This patch fixes this behaviour and adds a switch back between `date` and `datetime-local` on double click.

Workaround is needed because picker for type=datetime-local is broken in Firefox
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local