### PR TITLE
ZMI: monotonized complex input fields

### DIFF
--- a/Products/zms/import/com.zms.foundation-4.1.0.metaobj.xml
+++ b/Products/zms/import/com.zms.foundation-4.1.0.metaobj.xml
@@ -641,25 +641,40 @@ if 'permalink_key__' in request and 'permalink_val__' in request:
             <list>
               <item type="dictionary">
                 <dictionary>
-                  <item key="custom"><![CDATA[fas fa-download]]></item>
                   <item key="default"></item>
-                  <item key="id">icon_clazz</item>
+                  <item key="id">titlealt</item>
                   <item key="keys" type="list">
                     <list>
                     </list>
                   </item>
-                  <item key="mandatory" type="int">0</item>
-                  <item key="meta_type"></item>
-                  <item key="multilang" type="int">0</item>
-                  <item key="name"><![CDATA[Icon (Class)]]></item>
+                  <item key="mandatory" type="int">1</item>
+                  <item key="meta_type">titlealt</item>
+                  <item key="multilang" type="int">1</item>
+                  <item key="name">DC.Title.Alt</item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type">constant</item>
+                  <item key="type">string</item>
+                </dictionary>
+              </item>
+              <item type="dictionary">
+                <dictionary>
+                  <item key="default"></item>
+                  <item key="id">title</item>
+                  <item key="keys" type="list">
+                    <list>
+                    </list>
+                  </item>
+                  <item key="mandatory" type="int">1</item>
+                  <item key="meta_type">title</item>
+                  <item key="multilang" type="int">1</item>
+                  <item key="name">DC.Title</item>
+                  <item key="repetitive" type="int">0</item>
+                  <item key="type">string</item>
                 </dictionary>
               </item>
               <item type="dictionary">
                 <dictionary>
                   <item key="custom">
-                    <data content_type="text/plain" filename="default.css" type="file"><![CDATA[
+                    <data content_type="text/plain" filename="f_css_defaults" type="file"><![CDATA[
 div.ZMSFile.none, div.ZMSLinkElement.none 
 	{
 	background-color: transparent;
@@ -703,22 +718,6 @@ div.ZMSLinkElement div.title a:link, div.ZMSLinkElement div.title a:visited
               <item type="dictionary">
                 <dictionary>
                   <item key="default"></item>
-                  <item key="id">title</item>
-                  <item key="keys" type="list">
-                    <list>
-                    </list>
-                  </item>
-                  <item key="mandatory" type="int">1</item>
-                  <item key="meta_type">title</item>
-                  <item key="multilang" type="int">1</item>
-                  <item key="name">DC.Title</item>
-                  <item key="repetitive" type="int">0</item>
-                  <item key="type">string</item>
-                </dictionary>
-              </item>
-              <item type="dictionary">
-                <dictionary>
-                  <item key="default"></item>
                   <item key="id">file</item>
                   <item key="keys" type="list">
                     <list>
@@ -755,37 +754,28 @@ div.ZMSLinkElement div.title a:link, div.ZMSLinkElement div.title a:visited
               </item>
               <item type="dictionary">
                 <dictionary>
-                  <item key="default"></item>
-                  <item key="id">titlealt</item>
-                  <item key="keys" type="list">
-                    <list>
-                    </list>
-                  </item>
-                  <item key="mandatory" type="int">1</item>
-                  <item key="meta_type">titlealt</item>
-                  <item key="multilang" type="int">1</item>
-                  <item key="name">DC.Title.Alt</item>
-                  <item key="repetitive" type="int">0</item>
-                  <item key="type">string</item>
-                </dictionary>
-              </item>
-              <item type="dictionary">
-                <dictionary>
-                  <item key="custom"><![CDATA[<script type="text/javascript" tal:define="global
-		zmscontext options/zmscontext">
+                  <item key="custom"><![CDATA[<script type="text/javascript">
 
 $(function(){
-	$("#file_"+getZMILang()).change( function() {
-			var filename = $(this).val();
-			var i = Math.max(filename.lastIndexOf('/'),filename.lastIndexOf('\\'));
-			if (i > 0) {
-				filename = filename.substring(i+1);
-			}
-			var title = $("#title_"+getZMILang());
-			if (title.val().length == 0) {
-				title.attr({'data-value-attr':'placeholder','placeholder':filename});
-			}
-		});
+	$('#file_'+getZMILang()).change( function() {
+		var filename = $(this).val();
+		var i = Math.max(filename.lastIndexOf('/'),filename.lastIndexOf('\\'));
+		if (i > 0) {
+			filename = filename.substring(i+1);
+		}
+		var title = $('.ZMSFile.properties #title_'+getZMILang()+',.modal-body #title_'+getZMILang());
+		var titlealt = $('.ZMSFile.properties #titlealt_'+getZMILang()+',.modal-body #titlealt_'+getZMILang());
+		if (title.val().length == 0) {
+			title
+				.attr({'data-value-attr':'placeholder','placeholder':filename})
+				.val(filename)
+		};
+		if (titlealt.val().length == 0) {
+			titlealt
+				.attr({'data-value-attr':'placeholder','placeholder':filename})
+				.val(filename)
+		};
+	});
 });
 
 </script>]]>
@@ -834,6 +824,23 @@ $(function(){
                   <item key="name">DC.Description</item>
                   <item key="repetitive" type="int">0</item>
                   <item key="type">text</item>
+                </dictionary>
+              </item>
+              <item type="dictionary">
+                <dictionary>
+                  <item key="custom"><![CDATA[fas fa-download]]></item>
+                  <item key="default"></item>
+                  <item key="id">icon_clazz</item>
+                  <item key="keys" type="list">
+                    <list>
+                    </list>
+                  </item>
+                  <item key="mandatory" type="int">0</item>
+                  <item key="meta_type"></item>
+                  <item key="multilang" type="int">0</item>
+                  <item key="name"><![CDATA[Icon (Class)]]></item>
+                  <item key="repetitive" type="int">0</item>
+                  <item key="type">constant</item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -999,7 +1006,8 @@ return ''
 		<div tal:attributes="id python:zmscontext.id; class python:' '.join(subclass)">
 			<tal:block tal:condition="python:file">
 				<div class="title" tal:define="mt python:file.getContentType()">
-					<img tal:attributes="src python:zmscontext.getMimeTypeIconSrc(mt); title python:'%s (%s)'%(mt,file.getDataSizeStr())" border="0" alt="Icon" align="absmiddle"/>
+					<img style="width:1rem;vertical-align:bottom" src="data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cpath fill='%23666666' d='M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm76.45 211.36l-96.42 95.7c-6.65 6.61-17.39 6.61-24.04 0l-96.42-95.7C73.42 337.29 80.54 320 94.82 320H160v-80c0-8.84 7.16-16 16-16h32c8.84 0 16 7.16 16 16v80h65.18c14.28 0 21.4 17.29 11.27 27.36zM377 105L279.1 7c-4.5-4.5-10.6-7-17-7H256v128h128v-6.1c0-6.3-2.5-12.4-7-16.9z'%3E%3C/path%3E%3C/svg%3E"
+						tal:attributes="title python:'%s (%s)'%(mt,file.getDataSizeStr())" border="0" alt="Icon" align="absmiddle" />
 					<a tal:attributes="href python:file.getHref(request)" tal:content="structure python:titlealt" target="_blank">The titlealt</a>
 					(<span tal:content="python:file.getDataSizeStr()">The data-size string</span>)
 				</div>
@@ -1039,11 +1047,13 @@ return ''
                   <item></item>
                   <item></item>
                   <item></item>
+                  <item></item>
                 </list>
               </item>
               <item key="insert_custom">{$}</item>
               <item key="insert_deny" type="list">
                 <list>
+                  <item></item>
                   <item></item>
                   <item></item>
                   <item></item>
@@ -1055,7 +1065,7 @@ return ''
           <item key="id">ZMSFile</item>
           <item key="name">ZMSFile</item>
           <item key="package">com.zms.foundation</item>
-          <item key="revision">3.3.9</item>
+          <item key="revision">3.4.0</item>
           <item key="type">ZMSObject</item>
         </dictionary>
       </item>

--- a/Products/zms/import/com.zms.foundation-4.1.0.metaobj.xml
+++ b/Products/zms/import/com.zms.foundation-4.1.0.metaobj.xml
@@ -641,40 +641,25 @@ if 'permalink_key__' in request and 'permalink_val__' in request:
             <list>
               <item type="dictionary">
                 <dictionary>
+                  <item key="custom"><![CDATA[fas fa-download]]></item>
                   <item key="default"></item>
-                  <item key="id">titlealt</item>
+                  <item key="id">icon_clazz</item>
                   <item key="keys" type="list">
                     <list>
                     </list>
                   </item>
-                  <item key="mandatory" type="int">1</item>
-                  <item key="meta_type">titlealt</item>
-                  <item key="multilang" type="int">1</item>
-                  <item key="name">DC.Title.Alt</item>
+                  <item key="mandatory" type="int">0</item>
+                  <item key="meta_type"></item>
+                  <item key="multilang" type="int">0</item>
+                  <item key="name"><![CDATA[Icon (Class)]]></item>
                   <item key="repetitive" type="int">0</item>
-                  <item key="type">string</item>
-                </dictionary>
-              </item>
-              <item type="dictionary">
-                <dictionary>
-                  <item key="default"></item>
-                  <item key="id">title</item>
-                  <item key="keys" type="list">
-                    <list>
-                    </list>
-                  </item>
-                  <item key="mandatory" type="int">1</item>
-                  <item key="meta_type">title</item>
-                  <item key="multilang" type="int">1</item>
-                  <item key="name">DC.Title</item>
-                  <item key="repetitive" type="int">0</item>
-                  <item key="type">string</item>
+                  <item key="type">constant</item>
                 </dictionary>
               </item>
               <item type="dictionary">
                 <dictionary>
                   <item key="custom">
-                    <data content_type="text/plain" filename="f_css_defaults" type="file"><![CDATA[
+                    <data content_type="text/plain" filename="default.css" type="file"><![CDATA[
 div.ZMSFile.none, div.ZMSLinkElement.none 
 	{
 	background-color: transparent;
@@ -718,6 +703,22 @@ div.ZMSLinkElement div.title a:link, div.ZMSLinkElement div.title a:visited
               <item type="dictionary">
                 <dictionary>
                   <item key="default"></item>
+                  <item key="id">title</item>
+                  <item key="keys" type="list">
+                    <list>
+                    </list>
+                  </item>
+                  <item key="mandatory" type="int">1</item>
+                  <item key="meta_type">title</item>
+                  <item key="multilang" type="int">1</item>
+                  <item key="name">DC.Title</item>
+                  <item key="repetitive" type="int">0</item>
+                  <item key="type">string</item>
+                </dictionary>
+              </item>
+              <item type="dictionary">
+                <dictionary>
+                  <item key="default"></item>
                   <item key="id">file</item>
                   <item key="keys" type="list">
                     <list>
@@ -754,28 +755,37 @@ div.ZMSLinkElement div.title a:link, div.ZMSLinkElement div.title a:visited
               </item>
               <item type="dictionary">
                 <dictionary>
-                  <item key="custom"><![CDATA[<script type="text/javascript">
+                  <item key="default"></item>
+                  <item key="id">titlealt</item>
+                  <item key="keys" type="list">
+                    <list>
+                    </list>
+                  </item>
+                  <item key="mandatory" type="int">1</item>
+                  <item key="meta_type">titlealt</item>
+                  <item key="multilang" type="int">1</item>
+                  <item key="name">DC.Title.Alt</item>
+                  <item key="repetitive" type="int">0</item>
+                  <item key="type">string</item>
+                </dictionary>
+              </item>
+              <item type="dictionary">
+                <dictionary>
+                  <item key="custom"><![CDATA[<script type="text/javascript" tal:define="global
+		zmscontext options/zmscontext">
 
 $(function(){
-	$('#file_'+getZMILang()).change( function() {
-		var filename = $(this).val();
-		var i = Math.max(filename.lastIndexOf('/'),filename.lastIndexOf('\\'));
-		if (i > 0) {
-			filename = filename.substring(i+1);
-		}
-		var title = $('.ZMSFile.properties #title_'+getZMILang()+',.modal-body #title_'+getZMILang());
-		var titlealt = $('.ZMSFile.properties #titlealt_'+getZMILang()+',.modal-body #titlealt_'+getZMILang());
-		if (title.val().length == 0) {
-			title
-				.attr({'data-value-attr':'placeholder','placeholder':filename})
-				.val(filename)
-		};
-		if (titlealt.val().length == 0) {
-			titlealt
-				.attr({'data-value-attr':'placeholder','placeholder':filename})
-				.val(filename)
-		};
-	});
+	$("#file_"+getZMILang()).change( function() {
+			var filename = $(this).val();
+			var i = Math.max(filename.lastIndexOf('/'),filename.lastIndexOf('\\'));
+			if (i > 0) {
+				filename = filename.substring(i+1);
+			}
+			var title = $("#title_"+getZMILang());
+			if (title.val().length == 0) {
+				title.attr({'data-value-attr':'placeholder','placeholder':filename});
+			}
+		});
 });
 
 </script>]]>
@@ -824,23 +834,6 @@ $(function(){
                   <item key="name">DC.Description</item>
                   <item key="repetitive" type="int">0</item>
                   <item key="type">text</item>
-                </dictionary>
-              </item>
-              <item type="dictionary">
-                <dictionary>
-                  <item key="custom"><![CDATA[fas fa-download]]></item>
-                  <item key="default"></item>
-                  <item key="id">icon_clazz</item>
-                  <item key="keys" type="list">
-                    <list>
-                    </list>
-                  </item>
-                  <item key="mandatory" type="int">0</item>
-                  <item key="meta_type"></item>
-                  <item key="multilang" type="int">0</item>
-                  <item key="name"><![CDATA[Icon (Class)]]></item>
-                  <item key="repetitive" type="int">0</item>
-                  <item key="type">constant</item>
                 </dictionary>
               </item>
               <item type="dictionary">
@@ -1006,8 +999,7 @@ return ''
 		<div tal:attributes="id python:zmscontext.id; class python:' '.join(subclass)">
 			<tal:block tal:condition="python:file">
 				<div class="title" tal:define="mt python:file.getContentType()">
-					<img style="width:1rem;vertical-align:bottom" src="data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'%3E%3Cpath fill='%23666666' d='M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm76.45 211.36l-96.42 95.7c-6.65 6.61-17.39 6.61-24.04 0l-96.42-95.7C73.42 337.29 80.54 320 94.82 320H160v-80c0-8.84 7.16-16 16-16h32c8.84 0 16 7.16 16 16v80h65.18c14.28 0 21.4 17.29 11.27 27.36zM377 105L279.1 7c-4.5-4.5-10.6-7-17-7H256v128h128v-6.1c0-6.3-2.5-12.4-7-16.9z'%3E%3C/path%3E%3C/svg%3E"
-						tal:attributes="title python:'%s (%s)'%(mt,file.getDataSizeStr())" border="0" alt="Icon" align="absmiddle" />
+					<img tal:attributes="src python:zmscontext.getMimeTypeIconSrc(mt); title python:'%s (%s)'%(mt,file.getDataSizeStr())" border="0" alt="Icon" align="absmiddle"/>
 					<a tal:attributes="href python:file.getHref(request)" tal:content="structure python:titlealt" target="_blank">The titlealt</a>
 					(<span tal:content="python:file.getDataSizeStr()">The data-size string</span>)
 				</div>
@@ -1047,13 +1039,11 @@ return ''
                   <item></item>
                   <item></item>
                   <item></item>
-                  <item></item>
                 </list>
               </item>
               <item key="insert_custom">{$}</item>
               <item key="insert_deny" type="list">
                 <list>
-                  <item></item>
                   <item></item>
                   <item></item>
                   <item></item>
@@ -1065,7 +1055,7 @@ return ''
           <item key="id">ZMSFile</item>
           <item key="name">ZMSFile</item>
           <item key="package">com.zms.foundation</item>
-          <item key="revision">3.4.0</item>
+          <item key="revision">3.3.9</item>
           <item key="type">ZMSObject</item>
         </dictionary>
       </item>

--- a/Products/zms/plugins/www/zmi.core.css
+++ b/Products/zms/plugins/www/zmi.core.css
@@ -694,17 +694,6 @@ body.zmi  ul.zmi-container .right div input {
 body.zmi ul.zmi-container .zmi-item .zmi-action {
 	margin-left:-179px;
 }
-/* Fix left alignment on initially missing center-div */
-@media (max-width: 767px) {
-	.zmi-item.form-group.row > div.col-sm-10 > .zmi-action{
-		float:right;
-	}
-}
-@media (min-width: 768px) {
-	.zmi-item.form-group.row > div.col-sm-10 > .zmi-action {
-		margin-left:calc(100% - 20vw - 176px) !important;
-	}
-}
 body.zmi ul.zmi-container .zmi-item .zmi-action .split-left {
 	width:180px;
 	overflow:hidden;
@@ -1243,6 +1232,9 @@ div.pull-left div.single-line.input-append.zmi-nodes textarea {
 }
 .zmi .zmi-action .dropdown-menu:not(.dropdown-menu-right) a.dropdown-item:last-child {
 	margin-bottom: .5rem;
+}
+.zmi .zmi-action .dropdown-menu:not(.dropdown-menu-right) a.dropdown-item:first-child {
+	margin-bottom: unset;
 }
 .zmi .dropdown-menu .dropdown-header {
 	padding: 5px 13px;

--- a/Products/zms/zpt/ZMSObject/input_fields.zpt
+++ b/Products/zms/zpt/ZMSObject/input_fields.zpt
@@ -216,28 +216,43 @@
 						><tal:block tal:define="global
 									objChildren python:here.getObjChildren(metaObjAttr['id'],request);
 									hasChildren python:len(objChildren)>0">
-							<ul class="zmi-container" tal:condition="not:hasChildren">
-								<li class="zmi-item form-group row" tal:attributes="id python:'zmi_item_%s'%metaObjAttr['id']">
-									<label class="col-sm-2 control-label" tal:content="elLabel">the label</label>
-									<div class="col-sm-10">
-										<div class="zmi-action btn-group dropleft">
-											<span class="d-none zmi-sort-id" tal:content="python:9990">the sort-id</span>
-											<button class="btn btn-secondary split-left"></button>
-											<button class="btn btn-secondary split-right dropdown-toggle" data-toggle="dropdown"><i class="fas fa-plus-square"></i></button>
-										</div><!-- .btn-group -->
-									</div><!-- .col-sm-10 -->
-								</li><!-- .zmi-item -->
-							</ul>
+
+							<tal:block tal:condition="not:hasChildren">
+								<div class="card-header btn-collapse">
+									<a class="btn card-toggle pull-left" data-toggle="collapse" tal:attributes="href python:'#%s'%metaObjAttr['id']">
+										<i class="fas fa-caret-down"></i>
+										<tal:block tal:content="elLabel">the label</tal:block>
+									</a>
+									<div class="btn zmi-changes" tal:content="structure python:'(0 %s)'%(here.getZMILangStr('ATTR_OBJECTS'))">%i Objects</div>
+								</div><!-- .card-header -->
+								<div class="collapse zmi-children" tal:attributes="id python:metaObjAttr['id']">
+									<div class="card-body">
+										<ul class="zmi-container zmi-children">
+											<li class="zmi-item form-group" tal:attributes="id python:'zmi_item_%s'%metaObjAttr['id']">
+												<div class="center">&nbsp;</div>
+												<div class="right">
+													<div class="zmi-action btn-group dropleft">
+														<span class="d-none zmi-sort-id" tal:content="python:9990">the sort-id</span>
+														<button class="btn btn-secondary split-left"></button>
+														<button class="btn btn-secondary split-right dropdown-toggle" data-toggle="dropdown"><i class="fas fa-plus-square"></i></button>
+													</div><!-- .btn-group -->
+												</div><!-- .right -->
+											</li><!-- .zmi-item -->
+										</ul>
+									</div><!-- .card-body -->
+								</div><!-- .collapse -->
+							</tal:block>
+
 							<tal:block tal:condition="hasChildren">
 								<div class="card-header btn-collapse">
 									<a class="btn card-toggle pull-left" data-toggle="collapse" tal:attributes="href python:'#%s'%metaObjAttr['id'];data-toggle python:['','collapse'][hasChildren]">
 										<i tal:attributes="class python:'fas fa-%s'%(['caret-down',''][hasChildren])"></i>
 										<tal:block tal:content="elLabel">the label</tal:block>
 									</a>
-									<div class="btn zmi-changes" tal:content="structure python:'&nbsp;&nbsp;(%i %s)'%(len(objChildren),here.getZMILangStr('ATTR_OBJECTS'))">%i Objects</div>
+									<div class="btn zmi-changes" tal:content="structure python:'(%i %s)'%(len(objChildren),here.getZMILangStr('ATTR_OBJECTS'))">%i Objects</div>
 								</div><!-- .card-header -->
 								<tal:block tal:content="structure python:'<div id=\042%s\042 class=\042%s\042>'%(metaObjAttr['id'],' '.join(['collapse','zmi-children']+[[''],['show']][hasChildren])) +'<div class=\042card-body\042>'"></tal:block>
-								<ul class="zmi-container zmi-sortable">
+								<ul class="zmi-container zmi-sortable zmi-children">
 									<tal:block tal:repeat="childNode objChildren">
 										<li tal:attributes="id python:'zmi_item_%s'%childNode.id; class python:' '.join([childNode.meta_id,'zmi-item','zmi-selectable']+[['pageelement'],['page']][int(childNode.isPage())] + [[],['is-new']][int(childNode.inObjStates(['STATE_NEW'],request))] + [[],['is-modified']][int(childNode.inObjStates(['STATE_MODIFIED'],request))] + [[],['is-deleted']][int(childNode.inObjStates(['STATE_DELETED'],request))])">
 											<div class="center"


### PR DESCRIPTION
Hi @zmsdev ,
complex sub-elements of "special" content classes didd not appear in the typical grid layout.  This change https://github.com/zms-publishing/ZMS5/commit/c6fecb8a5188ebd652c77dfa6ffdcc1496dbde51 tried to fix it by CSS, but there is still a visual discrepancy between the cases hasChildren vs. not:hasChildren.
So I monotonized it (picture);  the cases hasChildren vs. not:hasChildren are still seperated in the TAL code. Maybe this not necessary and zpt/ZMSObject/input_fields.zpt  could get shorter. Any ideas?

![complex_appends](https://user-images.githubusercontent.com/29705216/122099915-db5d7380-ce12-11eb-9c6e-eae985daf277.png)
