### PR TITLE
declare unidentified coltypes as string

### DIFF
--- a/Products/zms/ZMSMetaobjManager.py
+++ b/Products/zms/ZMSMetaobjManager.py
@@ -91,7 +91,7 @@ class ZMSMetaobjManager(object):
 
     # Globals.
     # --------
-    valid_types =     ['amount', 'autocomplete', 'boolean', 'color', 'date', 'datetime', 'dictionary', 'file', 'float', 'identifier', 'image', 'int', 'list', 'multiautocomplete', 'multiselect', 'password', 'richtext', 'select', 'string', 'text', 'time', 'url', 'xml']
+    valid_types =     ['amount', 'autocomplete', 'boolean', 'color', 'date', 'datetime', 'dictionary', 'file', 'float', 'identifier', 'image', 'int', 'list', 'long', 'multiautocomplete', 'multiselect', 'password', 'richtext', 'select', 'string', 'text', 'time', 'url', 'xml']
     valid_zopeattrs = ['method', 'py', 'zpt', 'interface', 'resource']
     valid_xtypes =    ['constant', 'delimiter', 'hint']+valid_zopeattrs
     valid_datatypes = sorted(valid_types+valid_xtypes)
@@ -648,7 +648,7 @@ class ZMSMetaobjManager(object):
     #  Get attribute-id of identifier for datatable specified by meta-id.
     # --------------------------------------------------------------------------
     def getMetaobjAttrIdentifierId(self, meta_id):
-      for attr_id in self.getMetaobjAttrIds( meta_id, types=[ 'identifier', 'string', 'int']):
+      for attr_id in self.getMetaobjAttrIds( meta_id, types=[ 'identifier', 'string', 'int', 'long']):
         return attr_id
       return None
 

--- a/Products/zms/_globals.py
+++ b/Products/zms/_globals.py
@@ -123,6 +123,7 @@ DT_FILE = 5
 DT_FLOAT = 6
 DT_IMAGE = 7
 DT_INT = 8
+DT_LONG = 18
 DT_LIST = 9
 DT_PASSWORD = 10
 DT_STRING = 11
@@ -149,6 +150,7 @@ datatype_map = [
   [ 'float', 0.0],
   [ 'image', None],
   [ 'int', 0],
+  [ 'long', 0],
   [ 'list', []],
   [ 'password', ''],
   [ 'string', ''],

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -456,7 +456,7 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
     # --------------------------------------------------------------------------
     #  ZMSSqlDb.getEntityRecordHandler
     # --------------------------------------------------------------------------
-    def getEntityRecordHandler(self, tableName, stereotypes=['*']):
+    def getEntityRecordHandler(self, tableName, stereotypes=['*'], colNames=None):
       class EntityRecordHandler(object):
         def __init__(self, parent, tableName):
           self.parent = parent 
@@ -465,6 +465,8 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
         def handle_record(self, r):
           context = self.parent
           d = {}
+          if colNames:
+            r = { k:r[k] for k in r.keys() if k in colNames }
           for k in r:
             value = r[k]
             try:

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -370,10 +370,11 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
         for s in colName.split('_'):
           colLabel += s.capitalize()
         try:
-          colType = {'i':'int','n':'float','t':'string','s':'string','d':'datetime','l':'string'}[result_column['type']]
+          colType = {'i':'int','n':'float','t':'string','s':'string','d':'datetime','l':'string',None:'string'}[result_column['type']]
         except:
           colType = result_column.get('type', None)
           standard.writeError(self, '[query]: Column ' + colName + ' has unknown type ' + str(colType) + '!')
+          pass
         column = {}
         column['id'] = colName
         column['key'] = colName

--- a/Products/zms/zmssqldb.py
+++ b/Products/zms/zmssqldb.py
@@ -244,6 +244,11 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
           return str(int(str(v)))
         except:
           return "NULL"
+      elif col['type'] in ['long']:
+        try:
+          return str(long(str(v)))
+        except:
+          return "NULL"
       elif col['type'] in ['float']:
         try:
           return str(float(str(v)))
@@ -370,11 +375,10 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
         for s in colName.split('_'):
           colLabel += s.capitalize()
         try:
-          colType = {'i':'int','n':'float','t':'string','s':'string','d':'datetime','l':'string',None:'string'}[result_column['type']]
+          colType = {'i':'int','n':'float','t':'string','s':'string','d':'datetime','l':'long'}.get(result_column['type'],'string')
         except:
-          colType = result_column.get('type', None)
-          standard.writeError(self, '[query]: Column ' + colName + ' has unknown type ' + str(colType) + '!')
-          pass
+          colType = result_column.get('type', 'string')
+          standard.writeDebug(self, '[query]: Column ' + colName + ' has unknown type ' + str(colType) + '!')
         column = {}
         column['id'] = colName
         column['key'] = colName
@@ -1416,7 +1420,7 @@ class ZMSSqlDb(zmscustom.ZMSCustom):
           if tablecol.get('auto') in ['insert', 'update']:
             if tablecol.get('type') in ['date', 'datetime']:
               c.append({'id':id,'value':self.getLangFmtDate(time.time(), lang, '%s_FMT'%tablecol['type'].upper())})
-            elif tablecol.get('type') in ['int']:
+            elif tablecol.get('type') in ['int','long']:
               new_id = 0
               try:
                 rs = self.query('SELECT MAX(%s) AS max_id FROM %s'%(id, tablename))['records']

--- a/Products/zms/zpt/ZMSRecordSet/main_grid.zpt
+++ b/Products/zms/zpt/ZMSRecordSet/main_grid.zpt
@@ -195,7 +195,7 @@
 						><tal:block tal:condition="python:elType in ['date','datetime']"
 							><tal:block tal:content="python:here.getLangFmtDate(elValue,request['manage_lang'],('%s_fmt'%elType).upper())">elValue</tal:block
 						></tal:block
-						><tal:block tal:condition="python:elType in ['float','int']"
+						><tal:block tal:condition="python:elType in ['float','int','long']"
 							><tal:block tal:content="elValue">elValue</tal:block
 						></tal:block
 						><tal:block tal:condition="not:python:elType in ['boolean','date','datetime','float','html','image','file','int','object','url','None']"

--- a/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
+++ b/Products/zms/zpt/ZMSSqlDb/manage_main.zpt
@@ -165,8 +165,9 @@
 		</div><!-- .collapse -->
 	</div><!-- .card -->
 </form>
-
-<tal:block tal:define="dummy0 python:[here.operator_setitem(x,'name',x['label']) for x in metaObjAttrs]">
+<tal:block tal:define="
+	dummy0 python:[here.operator_setitem(x,'name',x['label']) for x in metaObjAttrs];
+	colNames python:[x['id'] for x in metaObjAttrs if x.get('hide',0) == 0]">
 	<tal:block tal:content="structure python:here.metaobj_recordset_main_grid(
 			metaObjAttrIds=metaObjAttrIds,
 			metaObjAttrs=metaObjAttrs,
@@ -177,7 +178,7 @@
 			filtered=True,
 			form_action=request['URL'],
 			url_params={'qentity':request.get('qentity')},
-			record_handler=here.getEntityRecordHandler(entity['id'],['blob']))">
+			record_handler=here.getEntityRecordHandler(entity['id'],['blob'],colNames))">
 		metaobj_recordset_main_grid
 	</tal:block>
 </tal:block>


### PR DESCRIPTION
Hello @zmsdev,
The zmssqldb-colType mapping refers to the basic types ZSQLMethods provides as parsed:
https://github.com/zopefoundation/Products.ZSQLMethods/blob/2c2d9799937868611135678b47d39275072a159e/src/Shared/DC/ZRDB/RDB.py#L40

Unluckily the fact, that many database field types do not refer to the parsed types we get a a huge amout of error log entries of any grid rendering. 
What about declaring the unparsed tpyes as string? 

Picture shows the two locations: e.g. you can see, that "l"/Long is mapped as string:
![long](https://user-images.githubusercontent.com/29705216/140823193-fd1bca33-3042-4a84-8b87-3152892c43f8.png)


